### PR TITLE
convert get-apps to stateless function

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -18,249 +18,252 @@ import ExternalLink from 'components/external-link';
 import analytics from 'lib/analytics';
 
 export default React.createClass( {
-	displayName: 'Site',
+  displayName: 'Site',
 
-	getDefaultProps() {
-		return {
-			// onSelect callback
-			onSelect: noop,
-			onClick: noop,
-			// mouse event callbacks
-			onMouseEnter: noop,
-			onMouseLeave: noop,
+  getDefaultProps() {
+    return {
+      // onSelect callback
+      onSelect: noop,
+      onClick: noop,
+      // mouse event callbacks
+      onMouseEnter: noop,
+      onMouseLeave: noop,
 
-			// Set a href attribute to the anchor
-			href: null,
+      // Set a href attribute to the anchor
+      href: null,
 
-			// Choose to show the SiteIndicator
-			indicator: true,
+      // Choose to show the SiteIndicator
+      indicator: true,
 
-			// Mark as selected or not
-			isSelected: false,
+      // Mark as selected or not
+      isSelected: false,
 
-			homeLink: false,
-			enableActions: false
-		};
-	},
+      homeLink: false,
+      enableActions: false
+    };
+  },
 
-	propTypes: {
-		href: React.PropTypes.string,
-		externalLink: React.PropTypes.bool,
-		indicator: React.PropTypes.bool,
-		onSelect: React.PropTypes.func,
-		onMouseEnter: React.PropTypes.func,
-		onMouseLeave: React.PropTypes.func,
-		isSelected: React.PropTypes.bool,
-		isHighlighted: React.PropTypes.bool,
-		site: React.PropTypes.object.isRequired,
-		onClick: React.PropTypes.func,
-		enableActions: React.PropTypes.bool
-	},
+  propTypes: {
+    href: React.PropTypes.string,
+    externalLink: React.PropTypes.bool,
+    indicator: React.PropTypes.bool,
+    onSelect: React.PropTypes.func,
+    onMouseEnter: React.PropTypes.func,
+    onMouseLeave: React.PropTypes.func,
+    isSelected: React.PropTypes.bool,
+    isHighlighted: React.PropTypes.bool,
+    site: React.PropTypes.object.isRequired,
+    onClick: React.PropTypes.func,
+    enableActions: React.PropTypes.bool
+  },
 
-	getInitialState() {
-		return {
-			showActions: false,
-			cogTooltip: false
-		};
-	},
+  getInitialState() {
+    return {
+      showActions: false,
+      cogTooltip: false
+    };
+  },
 
-	onSelect( event ) {
-		if ( this.props.homeLink ) {
-			return;
-		}
+  onSelect( event ) {
+    if ( this.props.homeLink ) {
+      return;
+    }
 
-		this.props.onSelect( event, this.props.site.slug );
-		event.preventDefault(); // this doesn't actually do anything...
-	},
+    this.props.onSelect( event, this.props.site.slug );
+    event.preventDefault(); // this doesn't actually do anything...
+  },
 
-	onMouseEnter( event ) {
-		this.props.onMouseEnter( event, this.props.site.slug );
-	},
+  onMouseEnter( event ) {
+    this.props.onMouseEnter( event, this.props.site.slug );
+  },
 
-	onMouseLeave( event ) {
-		this.props.onMouseLeave( event, this.props.site.slug );
-	},
+  onMouseLeave( event ) {
+    this.props.onMouseLeave( event, this.props.site.slug );
+  },
 
-	enableCogTooltip() {
-		this.setState( { cogTooltip: true } );
-	},
+  enableCogTooltip() {
+    this.setState( { cogTooltip: true } );
+  },
 
-	disableCogTooltip() {
-		this.setState( { cogTooltip: false } );
-	},
+  disableCogTooltip() {
+    this.setState( { cogTooltip: false } );
+  },
 
-	renderCog() {
-		const site = this.props.site;
+  renderCog() {
+    const site = this.props.site;
 
-		if ( ! site ) {
-			return null;
-		}
+    if ( ! site ) {
+      return null;
+    }
 
-		return (
-			<a
-				className="site__cog"
-				href={ `/settings/general/${ site.slug }` }
-				onClick={ this.onSettingsClick }
-				onMouseEnter={ this.enableCogTooltip }
-				onMouseLeave={ this.disableCogTooltip }
-				ref="cogButton"
-			>
-				<Gridicon icon="cog" />
-				<Tooltip
-					context={ this.refs && this.refs.cogButton }
-					isVisible={ this.state.cogTooltip }
-					position="bottom"
-				>
-					{ this.translate( 'Site settings' ) }
-				</Tooltip>
-			</a>
-		);
-	},
+    return (
+      <a
+        className="site__cog"
+        href={ `/settings/general/${ site.slug }` }
+        onClick={ this.onSettingsClick }
+        onMouseEnter={ this.enableCogTooltip }
+        onMouseLeave={ this.disableCogTooltip }
+        ref="cogButton"
+      >
+        <Gridicon icon="cog" />
+        <Tooltip
+          context={ this.refs && this.refs.cogButton }
+          isVisible={ this.state.cogTooltip }
+          position="bottom"
+        >
+          { this.translate( 'Site settings' ) }
+        </Tooltip>
+      </a>
+    );
+  },
 
-	renderEditIcon() {
-		if ( ! userCan( 'manage_options', this.props.site ) ) {
-			return <SiteIcon site={ this.props.site } />;
-		}
+  renderEditIcon() {
+    if ( ! userCan( 'manage_options', this.props.site ) ) {
+      return <SiteIcon site={ this.props.site } />;
+    }
 
-		let url = getCustomizeUrl( null, this.props.site ) + '&autofocus[section]=title_tagline';
+    let url = getCustomizeUrl( null, this.props.site ) + '&autofocus[section]=title_tagline';
 
-		if ( ! this.props.site.jetpack && this.props.site.options ) {
-			url = this.props.site.options.admin_url + 'options-general.php';
-		}
+    if ( ! this.props.site.jetpack && this.props.site.options ) {
+      url = this.props.site.options.admin_url + 'options-general.php';
+    }
 
-		/* eslint-disable react/jsx-no-target-blank */
-		return (
-			<ExternalLink icon={ true } href={ url } target="_blank" className="site__edit-icon" onClick={ this.onEditIconClick }>
-				<SiteIcon site={ this.props.site } />
-				<span className="site__edit-icon-text">{ this.translate( 'Edit Icon' ) }</span>
-			</ExternalLink>
-		);
-		/* eslint-enable react/jsx-no-target-blank */
-	},
+    /* eslint-disable react/jsx-no-target-blank */
+    return (
+      <ExternalLink icon={ true } href={ url } target="_blank" className="site__edit-icon" onClick={ this.onEditIconClick }>
+        <SiteIcon site={ this.props.site } />
+        <span className="site__edit-icon-text">{ this.translate( 'Edit Icon' ) }</span>
+      </ExternalLink>
+    );
+    /* eslint-enable react/jsx-no-target-blank */
+  },
 
-	getHref() {
-		if ( this.state.showMoreActions || ! this.props.site ) {
-			return null;
-		}
+  getHref() {
+    if ( this.state.showMoreActions || ! this.props.site ) {
+      return null;
+    }
 
-		return this.props.homeLink ? this.props.site.URL : this.props.href;
-	},
+    return this.props.homeLink ? this.props.site.URL : this.props.href;
+  },
 
-	closeActions() {
-		this.setState( { showMoreActions: false } );
-	},
+  closeActions() {
+    this.setState( { showMoreActions: false } );
+  },
 
-	toggleActions() {
-		if ( ! this.state.showMoreActions ) {
-			analytics.mc.bumpStat( 'calypso_site_card', 'toggle_button' );
-		}
-		this.setState( { showMoreActions: ! this.state.showMoreActions } );
-	},
+  toggleActions() {
+    if ( ! this.state.showMoreActions ) {
+      analytics.mc.bumpStat( 'calypso_site_card', 'toggle_button' );
+    }
+    this.setState( { showMoreActions: ! this.state.showMoreActions } );
+  },
 
-	onEditIconClick( event ) {
-		const site = this.props.site;
+  onEditIconClick( event ) {
+    const site = this.props.site;
 
-		if ( event ) {
-			analytics.mc.bumpStat( 'calypso_site_card', 'edit_icon' );
-		}
+    if ( event ) {
+      analytics.mc.bumpStat( 'calypso_site_card', 'edit_icon' );
+    }
 
-		if ( event && site && ! site.icon ) {
-			analytics.mc.bumpStat( 'calypso_site_card', 'edit_default_icon' );
-		}
-	},
+    if ( event && site && ! site.icon ) {
+      analytics.mc.bumpStat( 'calypso_site_card', 'edit_default_icon' );
+    }
+  },
 
-	onSettingsClick( event ) {
-		if ( event ) {
-			analytics.mc.bumpStat( 'calypso_site_card', 'settings' );
-		}
-	},
+  onSettingsClick( event ) {
+    if ( event ) {
+      analytics.mc.bumpStat( 'calypso_site_card', 'settings' );
+    }
+  },
 
-	render() {
-		const site = this.props.site;
+  render() {
+    const site = this.props.site;
 
-		if ( ! site ) {
-			// we could move the placeholder state here
-			return null;
-		}
+    if ( ! site ) {
+      // we could move the placeholder state here
+      return null;
+    }
 
-		const siteClass = classnames( {
-			site: true,
-			'is-jetpack': site.jetpack,
-			'is-primary': site.primary,
-			'is-private': site.is_private,
-			'is-redirect': site.options && site.options.is_redirect,
-			'is-selected': this.props.isSelected,
-			'is-highlighted': this.props.isHighlighted,
-			'is-toggled': this.state.showMoreActions,
-			'has-edit-capabilities': userCan( 'manage_options', site )
-		} );
+    const siteClass = classnames( {
+      site: true,
+      'is-jetpack': site.jetpack,
+      'is-primary': site.primary,
+      'is-private': site.is_private,
+      'is-redirect': site.options && site.options.is_redirect,
+      'is-selected': this.props.isSelected,
+      'is-highlighted': this.props.isHighlighted,
+      'is-toggled': this.state.showMoreActions,
+      'has-edit-capabilities': userCan( 'manage_options', site )
+    } );
 
-		return (
-			<div className={ siteClass }>
-				{ ! this.state.showMoreActions
-					? <a className="site__content"
-							href={ this.props.homeLink ? site.URL : this.props.href }
-							data-tip-target={ this.props.tipTarget }
-							target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
-							title={this.translate( 'Preview your site ')}
-							onTouchTap={ this.onSelect }
-							onClick={ this.props.onClick }
-							onMouseEnter={ this.onMouseEnter }
-							onMouseLeave={ this.onMouseLeave }
-							aria-label={ this.props.homeLink && site.is_previewable
-								? this.translate( 'Open site %(domain)s in a preview', {
-									args: { domain: site.domain }
-								} )
-								: this.translate( 'Open site %(domain)s in new tab', {
-									args: { domain: site.domain }
-								} )
-							}
-						>
-							<SiteIcon site={ site } />
-							<div className="site__info">
-								<div className="site__title">
-									{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-									{ this.props.site.is_private &&
-										<span className="site__badge">
-											<Gridicon icon="lock" size={ 14 } />
-										</span>
-									}
-									{ site.options && site.options.is_redirect &&
-										<span className="site__badge">
-											<Gridicon icon="block" size={ 14 } />
-										</span>
-									}
-									{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-									{ site.title }
-								</div>
-								<div className="site__domain">{ site.domain }</div>
-							</div>
-							{ this.props.homeLink &&
-								<span className="site__home">
-									<Gridicon icon="house" size={ 18 } />
-								</span>
-							}
-						</a>
-					: <div className="site__content">
-							{ this.renderEditIcon() }
-							<div className="site__actions">
-								{ this.renderCog() }
-							</div>
-						</div>
-				}
-				{ this.props.indicator
-					? <SiteIndicator site={ site } />
-					: null
-				}
-				{ this.props.enableActions &&
-					<button
-						className="site__toggle-more-options"
-						onClick={ this.toggleActions }
-					>
-						<Gridicon icon="ellipsis" size={ 24 } />
-					</button>
-				}
-			</div>
-		);
-	}
+    return (
+      <div className={ siteClass }>
+        { ! this.state.showMoreActions
+          ? <a className="site__content"
+              href={ this.props.homeLink ? site.URL : this.props.href }
+              data-tip-target={ this.props.tipTarget }
+              target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
+              title={ this.props.homeLink
+                ? this.translate( 'View "%(title)s"', { args: { title: site.title } } )
+                : site.title
+              }
+              onTouchTap={ this.onSelect }
+              onClick={ this.props.onClick }
+              onMouseEnter={ this.onMouseEnter }
+              onMouseLeave={ this.onMouseLeave }
+              aria-label={ this.props.homeLink && site.is_previewable
+                ? this.translate( 'Open site %(domain)s in a preview', {
+                  args: { domain: site.domain }
+                } )
+                : this.translate( 'Open site %(domain)s in new tab', {
+                  args: { domain: site.domain }
+                } )
+              }
+            >
+              <SiteIcon site={ site } />
+              <div className="site__info">
+                <div className="site__title">
+                  { /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+                  { this.props.site.is_private &&
+                    <span className="site__badge">
+                      <Gridicon icon="lock" size={ 14 } />
+                    </span>
+                  }
+                  { site.options && site.options.is_redirect &&
+                    <span className="site__badge">
+                      <Gridicon icon="block" size={ 14 } />
+                    </span>
+                  }
+                  { /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+                  { site.title }
+                </div>
+                <div className="site__domain">{ site.domain }</div>
+              </div>
+              { this.props.homeLink &&
+                <span className="site__home">
+                  <Gridicon icon="house" size={ 18 } />
+                </span>
+              }
+            </a>
+          : <div className="site__content">
+              { this.renderEditIcon() }
+              <div className="site__actions">
+                { this.renderCog() }
+              </div>
+            </div>
+        }
+        { this.props.indicator
+          ? <SiteIndicator site={ site } />
+          : null
+        }
+        { this.props.enableActions &&
+          <button
+            className="site__toggle-more-options"
+            onClick={ this.toggleActions }
+          >
+            <Gridicon icon="ellipsis" size={ 24 } />
+          </button>
+        }
+      </div>
+    );
+  }
 } );

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -14,68 +14,69 @@ import Button from 'components/button';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
-module.exports = React.createClass( {
 
-	displayName: 'GetApps',
+const defaultProps = {
+	displayName: 'GetApps'
+}
+function GetApps() {
+	return (
+		<Main className="get-apps">
+			<MeSidebarNavigation />
+			<SectionHeader label={ translate( 'Desktop apps' ) } />
+			<Card className="get-apps__desktop">
 
-	render: function() {
-		return (
-			<Main className="get-apps">
-				<MeSidebarNavigation />
-				<SectionHeader label={ translate( 'Desktop apps' ) } />
-				<Card className="get-apps__desktop">
+				<section className="get-apps__app">
+					<div className="get-apps__app-icon">
+						<img src="/calypso/images/me/get-apps-osx.svg" alt={ translate( 'Mac' ) } width="96" height="96" />
+					</div>
+					<p><strong>{ translate( 'Mac' ) }</strong><br />
+					{ translate( 'Requires 10.11 or newer' ) }</p>
+					<Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ translate( 'Download' ) }</Button>
+				</section>
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-osx.svg" alt={ translate( 'Mac' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ translate( 'Mac' ) }</strong><br />
-						{ translate( 'Requires 10.11 or newer' ) }</p>
-						<Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ translate( 'Download' ) }</Button>
-					</section>
+				<section className="get-apps__app">
+					<div className="get-apps__app-icon">
+						<img src="/calypso/images/me/get-apps-windows.svg" alt={ translate( 'Windows' ) } width="96" height="96" />
+					</div>
+					<p><strong>{ translate( 'Windows' ) }</strong><br />
+					{ translate( 'Requires 7 or newer' ) }</p>
+					<Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ translate( 'Download' ) }</Button>
+				</section>
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-windows.svg" alt={ translate( 'Windows' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ translate( 'Windows' ) }</strong><br />
-						{ translate( 'Requires 7 or newer' ) }</p>
-						<Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ translate( 'Download' ) }</Button>
-					</section>
+				<section className="get-apps__app">
+					<div className="get-apps__app-icon">
+						<img src="/calypso/images/me/get-apps-linux.svg" alt={ translate( 'Linux' ) } width="96" height="96" />
+					</div>
+					<p><strong>{ translate( 'Linux' ) }</strong><br />
+					{ translate( 'Choose your distribution' ) }</p>
+					<Button href="https://apps.wordpress.com/d/linux?ref=getapps">{ translate( '.TAR.GZ' ) }</Button> <Button href="https://apps.wordpress.com/d/linux-deb?ref=getapps">{ translate( '.DEB' ) }</Button>
+				</section>
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-linux.svg" alt={ translate( 'Linux' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ translate( 'Linux' ) }</strong><br />
-						{ translate( 'Choose your distribution' ) }</p>
-						<Button href="https://apps.wordpress.com/d/linux?ref=getapps">{ translate( '.TAR.GZ' ) }</Button> <Button href="https://apps.wordpress.com/d/linux-deb?ref=getapps">{ translate( '.DEB' ) }</Button>
-					</section>
+			</Card>
 
-				</Card>
+			<SectionHeader label={ translate( 'Mobile apps' ) } />
+			<Card className="get-apps__mobile">
 
-				<SectionHeader label={ translate( 'Mobile apps' ) } />
-				<Card className="get-apps__mobile">
+				<section className="get-apps__app">
+					<div className="get-apps__app-icon">
+						<img src="/calypso/images/me/get-apps-ios.svg" alt={ translate( 'iOS' ) } width="96" height="96" />
+					</div>
+					<p><strong>{ translate( 'iOS' ) }</strong></p>
+					<a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"><img src="/calypso/images/me/get-apps-app-store.png" alt={ translate( 'Get on the iOS App Store' ) } /></a>
+				</section>
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-ios.svg" alt={ translate( 'iOS' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ translate( 'iOS' ) }</strong></p>
-						<a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"><img src="/calypso/images/me/get-apps-app-store.png" alt={ translate( 'Get on the iOS App Store' ) } /></a>
-					</section>
+				<section className="get-apps__app">
+					<div className="get-apps__app-icon">
+						<img src="/calypso/images/me/get-apps-android.svg" alt={ translate( 'Android' ) } width="96" height="96" />
+					</div>
+					<p><strong>{ translate( 'Android' ) }</strong></p>
+					<a href="https://play.google.com/store/apps/details?id=org.wordpress.android"><img src="/calypso/images/me/get-apps-google-play.png" alt={ translate( 'Get on Google Play' ) } /></a>
+				</section>
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-android.svg" alt={ translate( 'Android' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ translate( 'Android' ) }</strong></p>
-						<a href="https://play.google.com/store/apps/details?id=org.wordpress.android"><img src="/calypso/images/me/get-apps-google-play.png" alt={ translate( 'Get on Google Play' ) } /></a>
-					</section>
+			</Card>
 
-				</Card>
-
-			</Main>
-		);
-	}
-} );
+		</Main>
+	);
+}
+GetApps.defaultProps = defaultProps;
+export default GetApps;

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React from 'react';
+import { translate } from 'i18n-calypso';
+
 
 /**
  * Internal dependencies
@@ -20,55 +22,55 @@ module.exports = React.createClass( {
 		return (
 			<Main className="get-apps">
 				<MeSidebarNavigation />
-				<SectionHeader label={ this.translate( 'Desktop apps' ) } />
+				<SectionHeader label={ translate( 'Desktop apps' ) } />
 				<Card className="get-apps__desktop">
 
 					<section className="get-apps__app">
 						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-osx.svg" alt={ this.translate( 'Mac' ) } width="96" height="96" />
+							<img src="/calypso/images/me/get-apps-osx.svg" alt={ translate( 'Mac' ) } width="96" height="96" />
 						</div>
-						<p><strong>{ this.translate( 'Mac' ) }</strong><br />
-						{ this.translate( 'Requires 10.11 or newer' ) }</p>
-						<Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ this.translate( 'Download' ) }</Button>
+						<p><strong>{ translate( 'Mac' ) }</strong><br />
+						{ translate( 'Requires 10.11 or newer' ) }</p>
+						<Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ translate( 'Download' ) }</Button>
 					</section>
 
 					<section className="get-apps__app">
 						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-windows.svg" alt={ this.translate( 'Windows' ) } width="96" height="96" />
+							<img src="/calypso/images/me/get-apps-windows.svg" alt={ translate( 'Windows' ) } width="96" height="96" />
 						</div>
-						<p><strong>{ this.translate( 'Windows' ) }</strong><br />
-						{ this.translate( 'Requires 7 or newer' ) }</p>
-						<Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ this.translate( 'Download' ) }</Button>
+						<p><strong>{ translate( 'Windows' ) }</strong><br />
+						{ translate( 'Requires 7 or newer' ) }</p>
+						<Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ translate( 'Download' ) }</Button>
 					</section>
 
 					<section className="get-apps__app">
 						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-linux.svg" alt={ this.translate( 'Linux' ) } width="96" height="96" />
+							<img src="/calypso/images/me/get-apps-linux.svg" alt={ translate( 'Linux' ) } width="96" height="96" />
 						</div>
-						<p><strong>{ this.translate( 'Linux' ) }</strong><br />
-						{ this.translate( 'Choose your distribution' ) }</p>
-						<Button href="https://apps.wordpress.com/d/linux?ref=getapps">{ this.translate( '.TAR.GZ' ) }</Button> <Button href="https://apps.wordpress.com/d/linux-deb?ref=getapps">{ this.translate( '.DEB' ) }</Button>
+						<p><strong>{ translate( 'Linux' ) }</strong><br />
+						{ translate( 'Choose your distribution' ) }</p>
+						<Button href="https://apps.wordpress.com/d/linux?ref=getapps">{ translate( '.TAR.GZ' ) }</Button> <Button href="https://apps.wordpress.com/d/linux-deb?ref=getapps">{ translate( '.DEB' ) }</Button>
 					</section>
 
 				</Card>
 
-				<SectionHeader label={ this.translate( 'Mobile apps' ) } />
+				<SectionHeader label={ translate( 'Mobile apps' ) } />
 				<Card className="get-apps__mobile">
 
 					<section className="get-apps__app">
 						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-ios.svg" alt={ this.translate( 'iOS' ) } width="96" height="96" />
+							<img src="/calypso/images/me/get-apps-ios.svg" alt={ translate( 'iOS' ) } width="96" height="96" />
 						</div>
-						<p><strong>{ this.translate( 'iOS' ) }</strong></p>
-						<a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"><img src="/calypso/images/me/get-apps-app-store.png" alt={ this.translate( 'Get on the iOS App Store' ) } /></a>
+						<p><strong>{ translate( 'iOS' ) }</strong></p>
+						<a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"><img src="/calypso/images/me/get-apps-app-store.png" alt={ translate( 'Get on the iOS App Store' ) } /></a>
 					</section>
 
 					<section className="get-apps__app">
 						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-android.svg" alt={ this.translate( 'Android' ) } width="96" height="96" />
+							<img src="/calypso/images/me/get-apps-android.svg" alt={ translate( 'Android' ) } width="96" height="96" />
 						</div>
-						<p><strong>{ this.translate( 'Android' ) }</strong></p>
-						<a href="https://play.google.com/store/apps/details?id=org.wordpress.android"><img src="/calypso/images/me/get-apps-google-play.png" alt={ this.translate( 'Get on Google Play' ) } /></a>
+						<p><strong>{ translate( 'Android' ) }</strong></p>
+						<a href="https://play.google.com/store/apps/details?id=org.wordpress.android"><img src="/calypso/images/me/get-apps-google-play.png" alt={ translate( 'Get on Google Play' ) } /></a>
 					</section>
 
 				</Card>

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -14,6 +14,9 @@ import SectionHeader from 'components/section-header';
 
 const defaultProps = {
   displayName: 'GetApps',
+};
+const propTypes = {
+  translate: PropTypes.func.isRequired,
 };
 const GetApps = ( { translate } ) => (
   <Main className="get-apps">
@@ -96,5 +99,6 @@ const GetApps = ( { translate } ) => (
 
   </Main>
 );
+GetApps.propTypes = propTypes;
 GetApps.defaultProps = defaultProps;
 export default localize( GetApps );

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var MeSidebarNavigation = require( 'me/sidebar-navigation' ),
-	Main = require( 'components/main' ),
-	Button = require( 'components/button' ),
-	Card = require( 'components/card' ),
-	SectionHeader = require( 'components/section-header' );
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import Main from 'components/main';
+import Button from 'components/button';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
 
 module.exports = React.createClass( {
 

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { translate } from 'i18n-calypso';
-
-
+import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
@@ -14,69 +12,89 @@ import Button from 'components/button';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
-
 const defaultProps = {
-	displayName: 'GetApps'
-}
-function GetApps() {
-	return (
-		<Main className="get-apps">
-			<MeSidebarNavigation />
-			<SectionHeader label={ translate( 'Desktop apps' ) } />
-			<Card className="get-apps__desktop">
+  displayName: 'GetApps',
+};
+const GetApps = ( { translate } ) => (
+  <Main className="get-apps">
+    <MeSidebarNavigation />
+    <SectionHeader label={ translate( 'Desktop apps' ) } />
+    <Card className="get-apps__desktop">
 
-				<section className="get-apps__app">
-					<div className="get-apps__app-icon">
-						<img src="/calypso/images/me/get-apps-osx.svg" alt={ translate( 'Mac' ) } width="96" height="96" />
-					</div>
-					<p><strong>{ translate( 'Mac' ) }</strong><br />
-					{ translate( 'Requires 10.11 or newer' ) }</p>
-					<Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ translate( 'Download' ) }</Button>
-				</section>
+      <section className="get-apps__app">
+        <div className="get-apps__app-icon">
+          <img src="/calypso/images/me/get-apps-osx.svg" alt={ translate( 'Mac' ) } width="96" height="96" />
+        </div>
+        <p><strong>{ translate( 'Mac' ) }</strong><br />
+        { translate( 'Requires 10.11 or newer' ) }</p>
+        <Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ translate( 'Download' ) }</Button>
+      </section>
 
-				<section className="get-apps__app">
-					<div className="get-apps__app-icon">
-						<img src="/calypso/images/me/get-apps-windows.svg" alt={ translate( 'Windows' ) } width="96" height="96" />
-					</div>
-					<p><strong>{ translate( 'Windows' ) }</strong><br />
-					{ translate( 'Requires 7 or newer' ) }</p>
-					<Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ translate( 'Download' ) }</Button>
-				</section>
+      <section className="get-apps__app">
+        <div className="get-apps__app-icon">
+          <img src="/calypso/images/me/get-apps-windows.svg" alt={ translate( 'Windows' ) } width="96" height="96" />
+        </div>
+        <p><strong>{ translate( 'Windows' ) }</strong><br />
+        { translate( 'Requires 7 or newer' ) }</p>
+        <Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ translate( 'Download' ) }</Button>
+      </section>
 
-				<section className="get-apps__app">
-					<div className="get-apps__app-icon">
-						<img src="/calypso/images/me/get-apps-linux.svg" alt={ translate( 'Linux' ) } width="96" height="96" />
-					</div>
-					<p><strong>{ translate( 'Linux' ) }</strong><br />
-					{ translate( 'Choose your distribution' ) }</p>
-					<Button href="https://apps.wordpress.com/d/linux?ref=getapps">{ translate( '.TAR.GZ' ) }</Button> <Button href="https://apps.wordpress.com/d/linux-deb?ref=getapps">{ translate( '.DEB' ) }</Button>
-				</section>
+      <section className="get-apps__app">
+        <div className="get-apps__app-icon">
+          <img src="/calypso/images/me/get-apps-linux.svg" alt={ translate( 'Linux' ) } width="96" height="96" />
+        </div>
+        <p><strong>{ translate( 'Linux' ) }</strong><br />
+        { translate( 'Choose your distribution' ) }</p>
+        <Button
+          href="https://apps.wordpress.com/d/linux?ref=getapps"
+        >
+          { translate( '.TAR.GZ' ) }
+        </Button>
+        <Button
+          href="https://apps.wordpress.com/d/linux-deb?ref=getapps"
+        >
+          { translate( '.DEB' ) }
+        </Button>
+      </section>
 
-			</Card>
+    </Card>
 
-			<SectionHeader label={ translate( 'Mobile apps' ) } />
-			<Card className="get-apps__mobile">
+    <SectionHeader label={ translate( 'Mobile apps' ) } />
+    <Card className="get-apps__mobile">
 
-				<section className="get-apps__app">
-					<div className="get-apps__app-icon">
-						<img src="/calypso/images/me/get-apps-ios.svg" alt={ translate( 'iOS' ) } width="96" height="96" />
-					</div>
-					<p><strong>{ translate( 'iOS' ) }</strong></p>
-					<a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"><img src="/calypso/images/me/get-apps-app-store.png" alt={ translate( 'Get on the iOS App Store' ) } /></a>
-				</section>
+      <section className="get-apps__app">
+        <div className="get-apps__app-icon">
+          <img src="/calypso/images/me/get-apps-ios.svg" alt={ translate( 'iOS' ) } width="96" height="96" />
+        </div>
+        <p><strong>{ translate( 'iOS' ) }</strong></p>
+        <a
+          href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"
+        >
+          <img
+            src="/calypso/images/me/get-apps-app-store.png"
+            alt={ translate( 'Get on the iOS App Store' ) }
+          />
+        </a>
+      </section>
 
-				<section className="get-apps__app">
-					<div className="get-apps__app-icon">
-						<img src="/calypso/images/me/get-apps-android.svg" alt={ translate( 'Android' ) } width="96" height="96" />
-					</div>
-					<p><strong>{ translate( 'Android' ) }</strong></p>
-					<a href="https://play.google.com/store/apps/details?id=org.wordpress.android"><img src="/calypso/images/me/get-apps-google-play.png" alt={ translate( 'Get on Google Play' ) } /></a>
-				</section>
+      <section className="get-apps__app">
+        <div className="get-apps__app-icon">
+          <img src="/calypso/images/me/get-apps-android.svg" alt={ translate( 'Android' ) } width="96" height="96" />
+        </div>
+        <p><strong>{ translate( 'Android' ) }</strong></p>
+        <a
+          href="https://play.google.com/store/apps/details?id=org.wordpress.android"
+        >
+          <img
+            src="/calypso/images/me/get-apps-google-play.png"
+            alt={ translate( 'Get on Google Play' ) }
+          />
+        </a>
+      </section>
 
-			</Card>
+    </Card>
 
-		</Main>
-	);
-}
+  </Main>
+);
 GetApps.defaultProps = defaultProps;
-export default GetApps;
+export default localize( GetApps );


### PR DESCRIPTION
1. Convert the component into a stateless functional component

1. Wrap it in the localize() function and use this.props.translate() from i18n-calypso instead of using this.translate()

Note: I accidentally left changes from issues 9086 / 9095 in  file `client/blocks/site/index.jsx`.

main issue stems from me working from my master branch for issue 8693. 

